### PR TITLE
Handle CRLF line endings in stdlib text readers

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -318,7 +318,10 @@ def basename(*args) -> Value.String:
 def _parse_lines(s: str) -> Value.Array:
     ans: List[Value.Base] = []
     if s:
-        ans = [Value.String(line) for line in (s[:-1] if s.endswith("\n") else s).split("\n")]
+        ans = [
+            Value.String(line.rstrip("\r"))
+            for line in (s[:-1] if s.endswith("\n") else s).split("\n")
+        ]
     return Value.Array(Type.String(), ans)
 
 

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -532,6 +532,8 @@ class TestStdLib(unittest.TestCase):
                 echo -e "key1\tvalue1" > map.txt
                 echo -e "key2\tvalue2" >> map.txt
                 echo -e "..\ttricky" >> map.txt
+                printf 'line1\r\n\r\nline3\r\n' > crlf_lines.txt
+                printf 'k1\tv1\r\nk2\tv2\r\n' > crlf_map.txt
             }
             output {
                 String i_strings_string = i1
@@ -540,6 +542,9 @@ class TestStdLib(unittest.TestCase):
                 Array[String] i_strings_lines = i2
                 Array[String] o_strings_lines = read_lines(strings2)
                 Array[String] o_names_lines = read_lines(stdout())
+                Array[String] o_crlf_lines = read_lines("crlf_lines.txt")
+                Array[Array[String]] o_crlf_tsv = read_tsv("crlf_map.txt")
+                Map[String,String] o_crlf_map = read_map("crlf_map.txt")
                 Int o_fortytwo = read_int("fortytwo.txt")
                 Float o_mole = read_float("mole.txt")
                 Array[Boolean] o_boolean = [read_boolean("true.txt"), read_boolean("false.txt")]
@@ -553,6 +558,9 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["i_strings_lines"], ["foo", "bar", "bas"])
         self.assertEqual(outputs["o_strings_lines"], ["foo", "bar", "bas"])
         self.assertEqual(outputs["o_names_lines"], ["Alyssa", "Ben"])
+        self.assertEqual(outputs["o_crlf_lines"], ["line1", "", "line3"])
+        self.assertEqual(outputs["o_crlf_tsv"], [["k1", "v1"], ["k2", "v2"]])
+        self.assertEqual(outputs["o_crlf_map"], {"k1": "v1", "k2": "v2"})
         self.assertEqual(outputs["o_fortytwo"], 42)
         self.assertEqual(outputs["o_boolean"], [True, False])
         self.assertEqual(outputs["o_map"], {"key1": "value1", "key2": "value2", "..": "tricky"})


### PR DESCRIPTION
### Motivation
- The stdlib text readers should remove trailing end-of-line characters per the WDL spec, including handling CRLF (`\r\n`) line endings without dropping blank lines.

### Description
- Update `_parse_lines` in `WDL/StdLib.py` to `rstrip("\r")` each split line so CR characters from CRLF endings are removed while preserving existing `"\n"` splitting semantics.
- Add regression coverage in `tests/test_5stdlib.py::test_read` that writes CRLF input files and asserts correct behavior for `read_lines`, `read_tsv`, and `read_map`, including a blank-line case to ensure empty lines are preserved.
- Reformat the updated tests file with `ruff format` to satisfy code-style expectations.

### Testing
- Ran inline assertions invoking `_parse_lines`, `_parse_tsv`, and `_parse_map` via a short Python script, which succeeded and validated CRLF handling and blank-line preservation.
- Ran `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_read` but the test run could not complete in this environment because Docker is unavailable and caused the task runtime to error; this is an environment limitation rather than a functional regression.
- Ran `ruff format` on the modified test file to ensure formatting consistency (file was reformatted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3c37de00833380df2f397e244080)