### PR TITLE
Fix StdLib behaviors (basename, TSV parsing, collect_by_key, zip/cross nonempty) and Map JSON collisions; add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,6 @@ These development tutorials under `docs/` introduce a few common ways the codeba
 - `wdlviz.md` -- generating graphviz diagrams from WDL source code
 - `add_functions.md `-- adding new functions to the standard library
 - `assert.md` -- adding a new WDL language feature, with parsing, type-checking, and runtime execution
+
+Test placement note:
+- StdLib-focused tests belong in `tests/test_5stdlib.py` (even when they only exercise expression-level stdlib behavior); keep `tests/test_0eval.py` for general expression/value evaluation coverage.

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -3,7 +3,7 @@ import math
 import os
 import json
 import tempfile
-from typing import List, Tuple, Dict, Callable, IO, Optional
+from typing import List, Tuple, Callable, IO, Optional
 from abc import ABC, abstractmethod
 from contextlib import suppress
 import regex
@@ -307,10 +307,10 @@ def basename(*args) -> Value.String:
     assert len(args) in (1, 2)
     assert isinstance(args[0], Value.String)
     path = args[0].value
-    if len(args) > 1:
+    if len(args) > 1 and not isinstance(args[1], Value.Null):
         assert isinstance(args[1], Value.String)
         suffix = args[1].value
-        if path.endswith(suffix):
+        if suffix and path.endswith(suffix):
             path = path[: -len(suffix)]
     return Value.String(os.path.basename(path))
 
@@ -333,9 +333,7 @@ def _parse_boolean(s: str) -> Value.Boolean:
 
 def _parse_tsv(s: str) -> Value.Array:
     ans: List[Value.Base] = [
-        Value.Array(
-            Type.Array(Type.String()), [Value.String(field) for field in line.value.split("\t")]
-        )
+        Value.Array(Type.String(), [Value.String(field) for field in line.value.split("\t")])
         for line in _parse_lines(s).value
     ]
     return Value.Array(Type.Array(Type.String()), ans)
@@ -815,7 +813,7 @@ class _ZipOrCross(EagerFunction):
             raise Error.IndeterminateType(expr.arguments[1], "can't infer item type of empty array")
         return Type.Array(
             Type.Pair(arg0ty.item_type, arg1ty.item_type),
-            nonempty=(arg0ty.nonempty or arg1ty.nonempty),
+            nonempty=(arg0ty.nonempty and arg1ty.nonempty),
         )
 
     def _coerce_args(
@@ -1133,20 +1131,23 @@ class _CollectByKey(EagerFunction):
         pairty = arg0ty.item_type
         assert isinstance(pairty, Type.Pair)
 
-        items: Dict[str, Tuple[Value.Base, List[Value.Base]]] = {}
+        items: List[Tuple[Value.Base, List[Value.Base]]] = []
         for p in arguments[0].value:
             assert isinstance(p, Value.Pair)
             ek = p.value[0].coerce(pairty.left_type)
             ev = p.value[1].coerce(pairty.right_type)
-            sk = str(ek)
-            if sk in items:
-                items[sk][1].append(ev)
-            else:
-                items[sk] = (ek, [ev])
+            found = False
+            for prior_k, prior_vs in items:
+                if ek == prior_k:
+                    prior_vs.append(ev)
+                    found = True
+                    break
+            if not found:
+                items.append((ek, [ev]))
 
         return Value.Map(
             (pairty.left_type, Type.Array(pairty.right_type)),
-            [(ek, Value.Array(pairty.right_type, evs)) for ek, evs in items.values()],
+            [(ek, Value.Array(pairty.right_type, evs)) for ek, evs in items],
             expr,
         )
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -3,7 +3,7 @@ import math
 import os
 import json
 import tempfile
-from typing import List, Tuple, Callable, IO, Optional
+from typing import List, Tuple, Dict, Callable, IO, Optional
 from abc import ABC, abstractmethod
 from contextlib import suppress
 import regex
@@ -1132,18 +1132,22 @@ class _CollectByKey(EagerFunction):
         assert isinstance(pairty, Type.Pair)
 
         items: List[Tuple[Value.Base, List[Value.Base]]] = []
+        buckets: Dict[str, List[int]] = {}
         for p in arguments[0].value:
             assert isinstance(p, Value.Pair)
             ek = p.value[0].coerce(pairty.left_type)
             ev = p.value[1].coerce(pairty.right_type)
+            bucket_key = f"{str(ek.type)}::{json.dumps(ek.json, sort_keys=True)}"
             found = False
-            for prior_k, prior_vs in items:
+            for i in buckets.get(bucket_key, []):
+                prior_k, prior_vs = items[i]
                 if ek == prior_k:
                     prior_vs.append(ev)
                     found = True
                     break
             if not found:
                 items.append((ek, [ev]))
+                buckets.setdefault(bucket_key, []).append(len(items) - 1)
 
         return Value.Map(
             (pairty.left_type, Type.Array(pairty.right_type)),

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -251,8 +251,10 @@ class Map(Base):
             raise (Error.EvalError(self.expr, msg) if self.expr else Error.RuntimeError(msg))
         for k, v in self.value:
             kstr = k.coerce(Type.String()).value
-            if kstr not in ans:
-                ans[kstr] = v.json
+            if kstr in ans:
+                msg = f"cannot write {str(self.type)} to JSON; colliding string key {json.dumps(kstr)}"
+                raise (Error.EvalError(self.expr, msg) if self.expr else Error.RuntimeError(msg))
+            ans[kstr] = v.json
         return ans
 
     def __str__(self) -> Any:

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -157,10 +157,13 @@ class TestEval(unittest.TestCase):
             ("1--4/3","3"), # -4/3 == -2, is this right?
             ("1/2.0","0.500000"),
             ("5.0/2","2.500000"),
+            ("5.0/2.0","2.500000"),
             ("-1/2.0","-0.500000"),
             ("4%2","0"),
             ("4%3","1"),
             ("min(0,1)","0"),
+            ("min(1,3.14)","1.000000"),
+            ("max(1.0,0)","1.000000"),
             ("max(1,3.14)*2","6.280000"),
             ("1 + false", "(Ln 1, Col 1) Non-numeric operand to + operator", WDL.Error.IncompatibleOperand),
             ("min(max(0,1),true)", "(Ln 1, Col 1) Non-numeric operand to min operator", WDL.Error.IncompatibleOperand),
@@ -586,6 +589,15 @@ class TestValue(unittest.TestCase):
                     WDL.Value.from_json(t[0],t[1])
             else:
                 self.assertEqual(t[1], WDL.Value.from_json(t[0],t[1]).json)
+
+        with self.assertRaises(WDL.Error.RuntimeError):
+            WDL.Value.Map(
+                (WDL.Type.Float(), WDL.Type.String()),
+                [
+                    (WDL.Value.Float(1.0000001), WDL.Value.String("a")),
+                    (WDL.Value.Float(1.0000002), WDL.Value.String("b")),
+                ],
+            ).json
 
         stdlib = WDL.StdLib.Base("1.0")
         self.assertEqual(

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -476,7 +476,7 @@ class BioWDLTasks(unittest.TestCase):
         "FileCoercion": 1,
         "OptionalCoercion": 11,
         "UnusedDeclaration": 12,
-        "NonemptyCoercion": 1,
+        "NonemptyCoercion": 2,
         "NameCollision": 1,
         "UnverifiedStruct": 1,
         "UnnecessaryQuantifier": 13,

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -46,6 +46,56 @@ class TestStdLib(unittest.TestCase):
         parsed = WDL.StdLib._parse_tsv("a\tb\n\nc\td\n")
         self.assertEqual(parsed.json, [["a", "b"], [""], ["c", "d"]])
 
+    def _eval_expr(self, expr: str, env=None, version: str = "development"):
+        env = env or WDL.Env.Bindings()
+        type_env = WDL.Env.Bindings()
+        for binding in env:
+            type_env = type_env.bind(binding.name, binding.value.type)
+        stdlib = WDL.StdLib.Base(version)
+        ex = WDL.parse_expr(expr, version=version).infer_type(type_env, stdlib)
+        return ex.eval(env, stdlib)
+
+    def test_collect_by_key_float_keys(self):
+        self.assertEqual(
+            str(self._eval_expr('length(keys(collect_by_key([(1.0000001,"a"),(1.0000002,"b")])))')),
+            "2",
+        )
+        self.assertEqual(
+            str(self._eval_expr('as_map([(1.0000001,"a"),(1.0000002,"b")])[1.0000002]')),
+            '"b"',
+        )
+
+    def test_zip_cross_nonempty_inference(self):
+        stdlib = WDL.StdLib.Base("development")
+        self.assertEqual(
+            str(
+                WDL.parse_expr("cross([1], range(0))", version="development")
+                .infer_type([], stdlib)
+                .type
+            ),
+            "Array[Pair[Int,Int]]",
+        )
+        self.assertEqual(
+            str(
+                WDL.parse_expr("zip([1], [2])", version="development")
+                .infer_type([], stdlib)
+                .type
+            ),
+            "Array[Pair[Int,Int]]+",
+        )
+
+    def test_basename_empty_suffix(self):
+        env = WDL.Env.Bindings().bind("sfx", WDL.Value.Null())
+        self.assertEqual(str(self._eval_expr('basename("/path/to/file.txt","")')), '"file.txt"')
+        self.assertEqual(str(self._eval_expr('basename("file.txt","")')), '"file.txt"')
+        self.assertEqual(str(self._eval_expr('basename("/path/to/file.txt",sfx)', env=env)), '"file.txt"')
+
+    def test_parse_tsv_row_type(self):
+        rows = WDL.StdLib._parse_tsv("alpha\tbeta\n")
+        self.assertEqual(rows.json, [["alpha", "beta"]])
+        self.assertEqual(str(rows.type), "Array[Array[String]]+")
+        self.assertEqual(str(rows.value[0].type), "Array[String]+")
+
     def test_eq_opt(self):
         # regression test issue #634
         wdl = """


### PR DESCRIPTION
### Motivation
- Correct several stdlib behavioral bugs around string/array/map handling and type inference that could lead to incorrect values or silent collisions when serializing to JSON.
- Ensure `basename` treats empty and `null` suffixes correctly and that TSV parsing produces rows with the right item type.
- Preserve ordering and proper equality when collecting by key and ensure `zip`/`cross` infer nonempty only when both inputs are nonempty.

### Description
- Tightened `basename` to ignore a `Null` suffix and to treat an empty suffix as a no-op by checking for an actual non-empty suffix before trimming. 
- Fixed `_parse_tsv` to construct per-row values as `Array[String]` (previously mis-typed) so row element types match their contents.
- Adjusted `zip`/`cross` nonempty inference to require both input arrays to be `nonempty` to yield a nonempty pair array. 
- Reworked `collect_by_key` to preserve insertion order and key equality by using a list of `(key, values)` pairs and comparing `Value` objects rather than stringifying keys.
- Made `Map.json` throw a runtime error on colliding string keys during JSON serialization instead of silently overwriting entries, with a clearer error message. 
- Minor typing import cleanup and added several unit tests covering the above fixes and related edge cases.

### Testing
- Ran the updated unit tests in `tests/test_0eval.py` and `tests/test_5stdlib.py` (targeted stdlib and value tests) using `pytest`, and they passed.
- Added tests include `test_collect_by_key_float_keys`, `test_zip_cross_nonempty_inference`, `test_basename_empty_suffix`, and JSON-collision checks for `Map.json`.
- Existing evaluation and value serialization tests in `tests/test_0eval.py` were extended and verified to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3bc51bbc83339181ecd05f0f3d01)