### PR TITLE
Ignore DeprecationWarning when decoding string escape sequences

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -15,6 +15,7 @@ given a suitable ``WDL.Env.Bindings[Value.Base]``.
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Tuple, Union, Iterable, Set, TYPE_CHECKING
 import codecs
+import warnings
 import regex
 from .Error import SourcePosition, SourceNode
 from . import Type, Value, Env, Error, StdLib, Any
@@ -436,8 +437,15 @@ class String(Base):
 
         # FIXME (issue #661): reject unicode-escape sequences that aren't allowed by the WDL spec
         try:
+
+            def decode_ascii(match: regex.Match) -> str:
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    return codecs.decode(match.group(0), "unicode-escape")
+
             return String._ASCII_PARTS_RE.sub(
-                lambda match: codecs.decode(match.group(0), "unicode-escape"), s
+                decode_ascii,
+                s,
             )
         except (SyntaxError, ValueError, UnicodeError):
             raise Error._BadCharacterEncoding(pos)


### PR DESCRIPTION
### Motivation
- Prevent spurious `DeprecationWarning` emitted by `codecs.decode(..., 'unicode-escape')` when decoding ASCII parts of WDL strings so decoding does not pollute logs on newer Python versions.

### Description
- Import `warnings` and wrap the ASCII-part decode in a `decode_ascii` helper that uses `warnings.catch_warnings()` with `warnings.filterwarnings("ignore", category=DeprecationWarning)`, and use that helper in `String._decode_escapes` via `String._ASCII_PARTS_RE.sub` in `WDL/Expr.py`.

### Testing
- Ran the project's unit tests including string-escape decoding checks and the full test suite with `pytest`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4ba7bfa8833389d938ee69f7d696)