### PR TITLE
Optimize repeated Map lookups with lazy index

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -461,10 +461,7 @@ class _At(EagerFunction):
             mkey = rhs
             if isinstance(mty, Type.Map):
                 mkey = mkey.coerce(mty.item_type[0])
-            ans = None
-            for k, v in lhs.value:
-                if mkey == k:
-                    ans = v
+            ans = lhs.get(mkey)
             if ans is None:
                 raise Error.OutOfBounds(expr.arguments[1], "Map key not found")
             return ans

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -231,6 +231,8 @@ class Array(Base):
 class Map(Base):
     value: List[Tuple[Base, Base]]
     type: Type.Map
+    _index: Optional[Dict[Any, Base]]
+    _index_failed: bool
 
     def __init__(
         self,
@@ -240,7 +242,28 @@ class Map(Base):
     ) -> None:
         self.value = []
         self.type = Type.Map(item_type)
+        self._index = None
+        self._index_failed = False
         super().__init__(self.type, value, expr)
+
+    def get(self, key: Base) -> Optional[Base]:
+        if not self._index_failed and self._index is None:
+            try:
+                self._index = {self._index_key(k): v for k, v in self.value}
+            except TypeError:
+                # Some legal WDL map key types (e.g. arrays) may be unhashable as Python dict keys.
+                self._index_failed = True
+                self._index = None
+        if self._index is not None:
+            return self._index.get(self._index_key(key))
+        for k, v in self.value:
+            if key == k:
+                return v
+        return None
+
+    @staticmethod
+    def _index_key(key: Base) -> Any:
+        return key.value
 
     @property
     def json(self) -> Any:


### PR DESCRIPTION
### Motivation
- Repeated WDL `Map` key lookups were doing a linear scan of `Value.Map.value` on every access, which is inefficient for common cases with many lookups.
- Make a small, low-risk optimization that reuses a Python `dict` index after the first lookup to improve performance without large refactors.

### Description
- Add cached index fields to `WDL.Value.Map`: `_index` and `_index_failed`, and initialize them in `__init__`.
- Implement `WDL.Value.Map.get(key)` which lazily builds `_index` on first lookup, uses `_index` for subsequent lookups, and falls back to the original linear scan when keys are unhashable in Python.
- Provide `_index_key()` helper that derives the Python dict key from a `Value.Base` (currently returns `key.value`).
- Switch stdlib map access in `_At._call_eager` to use `Value.Map.get()` so the optimization applies to `map[key]` evaluations.

### Testing
- Ran formatting and static checks: `ruff format WDL/Value.py WDL/StdLib.py` and `ruff check WDL/Value.py WDL/StdLib.py`, which passed.
- Ran type checks with `mypy WDL/Value.py WDL/StdLib.py`, which passed.
- Ran targeted unit tests with `pytest -q tests/test_0eval.py -k map`, which passed (`1 passed, 22 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25ba6e28883338ec0a392c1baa5e4)