### PR TITLE
Add stdlib unit coverage for length() and contains_key() edge branches

### DIFF
--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -386,6 +386,10 @@ class TestStdLib(unittest.TestCase):
         }
         """, expected_exception=WDL.Error.EvalError)
 
+
+        with self.assertRaises(WDL.Error.WrongArity):
+            self._eval_expr("length([1], [2])", version="1.2")
+
         # Test length() with Maps
         outputs = self._test_task(R"""
         version 1.2
@@ -3325,6 +3329,109 @@ class TestStdLib(unittest.TestCase):
             type_env, WDL.StdLib.Base("1.2")
         )
         self.assertIsInstance(expr.type, WDL.Type.Boolean)
+
+
+        # Error: optional map not allowed when check_quant=True
+        optional_map_wdl = R"""
+        version 1.2
+        task bad {
+            input {
+                Map[String, Int]? m = {"a": 1}
+            }
+            command {}
+            output {
+                Boolean x = contains_key(m, "a")
+            }
+        }
+        """
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            WDL.parse_document(optional_map_wdl).typecheck()
+
+        # Error: nested key paths on maps require String keys
+        self._test_task(R"""
+        version 1.2
+        task bad {
+            input {
+                Map[Int, Int] m = {1: 10}
+            }
+            command {}
+            output {
+                Boolean x = contains_key(m, ["1"])
+            }
+        }
+        """, expected_exception=WDL.Error.StaticTypeMismatch)
+
+        # Error: struct/object lookup key must be String or Array[String]
+        self._test_task(R"""
+        version 1.2
+        struct Box {
+            Int v
+        }
+        task bad {
+            input {
+                Box b = Box {v: 1}
+            }
+            command {}
+            output {
+                Boolean x = contains_key(b, 1)
+            }
+        }
+        """, expected_exception=WDL.Error.StaticTypeMismatch)
+
+        # Error: contains_key(read_json()) key must be String or Array[String]
+        self._test_task(R"""
+        version 1.2
+        task bad {
+            command <<<
+                echo '{"x": 1}' > data.json
+            >>>
+            output {
+                Boolean x = contains_key(read_json("data.json"), 1)
+            }
+        }
+        """, expected_exception=WDL.Error.StaticTypeMismatch)
+
+        # Error: nested key array must be Array[String]
+        self._test_task(R"""
+        version 1.2
+        task bad {
+            input {
+                Map[String, Int] m = {"a": 1}
+            }
+            command {}
+            output {
+                Boolean x = contains_key(m, [1])
+            }
+        }
+        """, expected_exception=WDL.Error.StaticTypeMismatch)
+
+        # Runtime: nested lookup falls through non-collection intermediates
+        outputs = self._test_task(R"""
+        version 1.2
+        task test_contains_key_nested_scalar {
+            command {}
+            output {
+                Boolean has_a_b = contains_key({"a": 1}, ["a", "b"])
+            }
+        }
+        """)
+        self.assertEqual(outputs["has_a_b"], False)
+
+        # Runtime: empty nested key path always returns false
+        outputs = self._test_task(R"""
+        version 1.2
+        task test_contains_key_nested_empty {
+            input {
+                Map[String, Int] m = {"a": 1}
+                Array[String] path = []
+            }
+            command {}
+            output {
+                Boolean has_empty = contains_key(m, path)
+            }
+        }
+        """)
+        self.assertEqual(outputs["has_empty"], False)
 
         # Error: first argument not a collection
         self._test_task(R"""


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for `WDL/StdLib.py` to exercise several error and edge branches in `length()` and `contains_key()` implementation paths. 
- Ensure static typechecking and runtime behaviors (nested-key traversal, optional-key rules, and wrong-arity handling) are validated to prevent regressions.

### Description
- Add an explicit wrong-arity assertion for `length()` to exercise the `WrongArity` branch in `_Length.infer_type` by invoking `length([1], [2])` in `tests/test_5stdlib.py`.
- Extend `test_contains_key` in `tests/test_5stdlib.py` with negative static-type cases covering optional-map quantifier rejection, nested-key paths on non-`String`-key maps, struct/object key type mismatch, and invalid `read_json()` key types.
- Add nested-key validation tests that assert the nested-key array element type must be `String` and runtime cases that verify traversal falls through non-collection intermediates and that empty nested-key arrays return `false`.
- All new checks are implemented as unit tests in `tests/test_5stdlib.py` that map to the relevant `StdLib` branches (type errors and runtime `EvalError`/boolean outcomes).

### Testing
- Ran `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_length_defined_range tests.test_5stdlib.TestStdLib.test_contains_key` which aborted with environment errors due to the Docker daemon socket being unavailable and raised `docker.errors.DockerException` during task execution, so the runtime task cases could not complete in this environment.
- Ran `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_contains_key` which also failed for the same reason (`DockerException: Error while fetching server API version: FileNotFoundError`), indicating the failures are environmental rather than test assertions; these tests should pass in CI or a developer environment with Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef92d544c8333a20f829ebc0856d4)