### PR TITLE
Improve size() error for compound arguments without File/Directory

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -802,7 +802,12 @@ class _Size(EagerFunction):
             raise Error.WrongArity(expr, 1)
         arg0ty = expr.arguments[0].type
         if not self._accepts_type(arg0ty):
-            raise Error.StaticTypeMismatch(expr.arguments[0], Type.File(optional=True), arg0ty)
+            message = ""
+            if arg0ty.parameters:
+                message = "size() argument is a compound type lacking any File/Directory"
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], Type.File(optional=True), arg0ty, message
+            )
         if len(expr.arguments) == 2:
             if expr.arguments[1].type != Type.String():
                 raise Error.StaticTypeMismatch(

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -389,13 +389,18 @@ class TestStdLib(unittest.TestCase):
             ("Float sz = size({})", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(None)", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(read_json(\"x.json\"))", WDL.Error.StaticTypeMismatch),
-            ("Float sz = size(ints)", WDL.Error.StaticTypeMismatch),
-            ("Float sz = size(string_to_int)", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(dir1,dir2)", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(dir1,[dir2])", WDL.Error.StaticTypeMismatch),
         ]:
             doc = WDL.parse_document(tmpl.format(case[0]))
             with self.assertRaises(case[1]):
+                doc.typecheck()
+
+        for case in ["Float sz = size(ints)", "Float sz = size(string_to_int)"]:
+            doc = WDL.parse_document(tmpl.format(case))
+            with self.assertRaisesRegex(
+                WDL.Error.StaticTypeMismatch, "compound type lacking any File/Directory"
+            ):
                 doc.typecheck()
 
         with self.assertRaises(WDL.Error.InputError):


### PR DESCRIPTION
### Motivation
- Make the static type error from `size()` clearer when the first argument is a compound WDL type that contains no `File` or `Directory` members, so users understand the cause without guessing about coercion rules.

### Description
- In `WDL/StdLib.py`, update `_Size.infer_type` to attach the message `"size() argument is a compound type lacking any File/Directory"` on `StaticTypeMismatch` when the rejected argument is a compound type (checked via `arg0ty.parameters`).
- Preserve existing acceptance and coercion behavior for path-bearing types and legacy top-level `String`/`Array[String]` forms by only adding the explanatory message for the specific non-path compound case.
- Add assertions in `tests/test_5stdlib.py` (`test_size_polytype`) to expect the new message for representative non-path compound inputs (`Array[Int]` and `Map[String, Int]`).

### Testing
- Ran `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_size_polytype`, which completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7ea8a188333b937021162fb3d8c)