### PR TITLE
Implement WDL 1.2 write_tsv object/header signatures

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -134,9 +134,7 @@ class Base:
         static([Type.Array(Type.String())], Type.File(), "write_lines")(
             self._write(_serialize_lines)
         )
-        static([Type.Array(Type.Array(Type.String()))], Type.File(), "write_tsv")(
-            self._write(_serialize_tsv)
-        )
+        self.write_tsv = _WriteTsv(self)
         static([Type.Map((Type.Any(), Type.Any()))], Type.File(), "write_map")(
             self._write(_serialize_map)
         )
@@ -471,6 +469,26 @@ def _serialize_tsv(v: Value.Base, outfile: IO[bytes]) -> None:
         ),
         outfile,
     )
+
+
+def _serialize_tsv_objects(v: Value.Base, outfile: IO[bytes], *, header: bool = False) -> None:
+    assert isinstance(v, Value.Array)
+    rows: List[Value.Base] = []
+    map_columns: Optional[List[str]] = None
+    for row in v.value:
+        if not isinstance(row, Value.Map):
+            raise ValueError("write_tsv(): unsupported row type")
+        columns = [k.coerce(Type.String()).value for (k, _) in row.value]
+        if len(set(columns)) < len(columns):
+            raise ValueError("write_tsv(): object column names must be unique")
+        if map_columns is None:
+            map_columns = columns
+            if header:
+                rows.append(Value.String("\t".join(columns)))
+        elif columns != map_columns:
+            raise ValueError("write_tsv(): object rows must have matching keys in matching order")
+        rows.append(Value.String("\t".join(v.coerce(Type.String()).value for (_, v) in row.value)))
+    _serialize_lines(Value.Array(Type.String(), rows), outfile)
 
 
 def _serialize_map(map: Value.Base, outfile: IO[bytes]) -> None:
@@ -972,6 +990,65 @@ class _ReadTsv(EagerFunction):
             if str(exn):
                 msg += ", " + str(exn)
             raise Error.EvalError(expr, msg) from exn
+
+
+class _WriteTsv(EagerFunction):
+    stdlib: Base
+
+    def __init__(self, stdlib: Base) -> None:
+        self.stdlib = stdlib
+
+    def infer_type(self, expr: "Expr.Apply") -> Type.Base:
+        if not expr.arguments:
+            raise Error.WrongArity(expr, 1)
+        if len(expr.arguments) > 2:
+            raise Error.WrongArity(expr, 2)
+        arg0ty = expr.arguments[0].type
+        row_tsv = Type.Array(Type.String())
+        row_obj = Type.Map((Type.String(), Type.String()))
+        if isinstance(arg0ty, Type.Array) and (
+            arg0ty.item_type.coerces(row_tsv) or arg0ty.item_type.coerces(row_obj)
+        ):
+            pass
+        else:
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], Type.Array(Type.Any()), arg0ty, "for write_tsv argument #1"
+            )
+        if len(expr.arguments) == 2:
+            if not wdl_version_geq(self.stdlib.wdl_version, WDLVersion.V1_2):
+                raise Error.WrongArity(expr, 1)
+            try:
+                expr.arguments[1].typecheck(Type.Boolean())
+            except Error.StaticTypeMismatch:
+                raise Error.StaticTypeMismatch(
+                    expr.arguments[1],
+                    Type.Boolean(),
+                    expr.arguments[1].type,
+                    "for write_tsv argument #2",
+                ) from None
+            if arg0ty.item_type.coerces(row_tsv):
+                raise Error.StaticTypeMismatch(
+                    expr.arguments[0],
+                    Type.Array(row_obj),
+                    arg0ty,
+                    "write_tsv(Array[Array[String]], Boolean) is not supported",
+                )
+        return Type.File()
+
+    def _call_eager(self, expr: "Expr.Apply", arguments: List[Value.Base]) -> Value.Base:
+        header = False
+        if len(arguments) == 2:
+            header = arguments[1].coerce(Type.Boolean()).value
+        arg0ty = expr.arguments[0].type
+        assert isinstance(arg0ty, Type.Array)
+        object_rows = arg0ty.item_type.coerces(Type.Map((Type.String(), Type.String())))
+        return self.stdlib._write(
+            lambda v, outfile: (
+                _serialize_tsv_objects(v, outfile, header=header)
+                if object_rows
+                else _serialize_tsv(v, outfile)
+            )
+        )(arguments[0])
 
 
 class _SelectFirst(EagerFunction):

--- a/tests/spec_tests/config.yaml
+++ b/tests/spec_tests/config.yaml
@@ -23,7 +23,6 @@ wdl-1.2:
     - chunk_array.wdl
     - join_paths_task.wdl
     - relative_paths_context.wdl  # issue #869
-    - write_tsv_task.wdl
     # Known spec deviations:
     - file_sizes_task.wdl       # expected output is malformed
     - one_mount_point_task.wdl  # issue #868

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -1,24 +1,22 @@
-from math import exp
 import unittest
 import logging
 import tempfile
 import os
 import json
-import docker
 from .context import WDL
 
-class TestStdLib(unittest.TestCase):
 
+class TestStdLib(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s %(levelname)s %(message)s")
         logger = logging.getLogger(cls.__name__)
         cfg = WDL.runtime.config.Loader(logger, [])
 
     def setUp(self):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_stdlib_")
 
-    def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None, cfg = None):
+    def _test_task(self, wdl: str, inputs=None, expected_exception: Exception = None, cfg=None):
         cfg = cfg or WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
         try:
             doc = WDL.parse_document(wdl)
@@ -26,8 +24,12 @@ class TestStdLib(unittest.TestCase):
             doc.typecheck()
             assert len(doc.tasks[0].required_inputs.subtract(doc.tasks[0].available_inputs)) == 0
             if isinstance(inputs, dict):
-                inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
-            rundir, outputs = WDL.runtime.run(cfg, doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, max_tasks=1)
+                inputs = WDL.values_from_json(
+                    inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs
+                )
+            rundir, outputs = WDL.runtime.run(
+                cfg, doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, max_tasks=1
+            )
         except WDL.runtime.RunFailed as exn:
             if expected_exception:
                 self.assertIsInstance(exn.__context__, expected_exception)
@@ -48,7 +50,9 @@ class TestStdLib(unittest.TestCase):
 
     def test_parse_tsv_objects(self):
         parsed = WDL.StdLib._parse_tsv_objects("name\tlane\nAlice\t3\nBob\t4\n")
-        self.assertEqual(parsed.json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}])
+        self.assertEqual(
+            parsed.json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}]
+        )
 
         parsed = WDL.StdLib._parse_tsv_objects(
             "Alice\t3\nBob\t4\n",
@@ -56,7 +60,9 @@ class TestStdLib(unittest.TestCase):
             keys=[WDL.Value.String("name"), WDL.Value.String("lane")],
             function_name="read_tsv",
         )
-        self.assertEqual(parsed.json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}])
+        self.assertEqual(
+            parsed.json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}]
+        )
 
         parsed = WDL.StdLib._parse_tsv_objects(
             "",
@@ -110,22 +116,34 @@ class TestStdLib(unittest.TestCase):
 
         expr, stdlib = infer("read_tsv({})".format(json.dumps(table)))
         self.assertEqual(expr.type, WDL.Type.Array(WDL.Type.Array(WDL.Type.String())))
-        self.assertEqual(expr.eval(WDL.Env.Bindings(), stdlib).json, [["name", "lane"], ["Alice", "3"], ["Bob", "4"]])
+        self.assertEqual(
+            expr.eval(WDL.Env.Bindings(), stdlib).json,
+            [["name", "lane"], ["Alice", "3"], ["Bob", "4"]],
+        )
 
         expr, stdlib = infer("read_tsv({}, true)".format(json.dumps(table)))
-        self.assertEqual(expr.type, WDL.Type.Array(WDL.Type.Map((WDL.Type.String(), WDL.Type.String()))))
-        self.assertEqual(expr.eval(WDL.Env.Bindings(), stdlib).json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}])
-
-        expr, stdlib = infer(
-            "read_tsv({}, false, [\"name\", \"lane\"])".format(json.dumps(no_header))
+        self.assertEqual(
+            expr.type, WDL.Type.Array(WDL.Type.Map((WDL.Type.String(), WDL.Type.String())))
         )
-        self.assertEqual(expr.type, WDL.Type.Array(WDL.Type.Map((WDL.Type.String(), WDL.Type.String()))))
-        self.assertEqual(expr.eval(WDL.Env.Bindings(), stdlib).json, [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}])
-
-        expr, stdlib = infer(
-            "read_tsv({}, true, [\"sample\", \"value\"])".format(json.dumps(table))
+        self.assertEqual(
+            expr.eval(WDL.Env.Bindings(), stdlib).json,
+            [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}],
         )
-        self.assertEqual(expr.eval(WDL.Env.Bindings(), stdlib).json, [{"sample": "Alice", "value": "3"}, {"sample": "Bob", "value": "4"}])
+
+        expr, stdlib = infer('read_tsv({}, false, ["name", "lane"])'.format(json.dumps(no_header)))
+        self.assertEqual(
+            expr.type, WDL.Type.Array(WDL.Type.Map((WDL.Type.String(), WDL.Type.String())))
+        )
+        self.assertEqual(
+            expr.eval(WDL.Env.Bindings(), stdlib).json,
+            [{"name": "Alice", "lane": "3"}, {"name": "Bob", "lane": "4"}],
+        )
+
+        expr, stdlib = infer('read_tsv({}, true, ["sample", "value"])'.format(json.dumps(table)))
+        self.assertEqual(
+            expr.eval(WDL.Env.Bindings(), stdlib).json,
+            [{"sample": "Alice", "value": "3"}, {"sample": "Bob", "value": "4"}],
+        )
 
         expr, stdlib = infer('read_tsv("/no/such/file.tsv")')
         with self.assertRaises(WDL.Error.EvalError):
@@ -141,6 +159,7 @@ class TestStdLib(unittest.TestCase):
         expr, stdlib = infer("read_tsv({}, true)".format(json.dumps(table)))
         parse_tsv_objects = WDL.StdLib._parse_tsv_objects
         try:
+
             def raise_eval_error(*args, **kwargs):
                 raise WDL.Error.EvalError(expr, "sentinel")
 
@@ -149,6 +168,56 @@ class TestStdLib(unittest.TestCase):
                 expr.eval(WDL.Env.Bindings(), stdlib)
         finally:
             WDL.StdLib._parse_tsv_objects = parse_tsv_objects
+
+    def test_write_tsv_unit_branches(self):
+        class LocalStdLib(WDL.StdLib.Base):
+            def _devirtualize_filename(self, filename: str) -> str:
+                return filename
+
+            def _virtualize_filename(self, filename: str) -> str:
+                return filename
+
+        with self.assertRaises(WDL.Error.WrongArity):
+            self._infer_expr_type("write_tsv()", version="1.2")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._infer_expr_type('write_tsv("x")', version="1.2")
+        with self.assertRaises(WDL.Error.WrongArity):
+            self._infer_expr_type("write_tsv([], true, false)", version="1.2")
+        with self.assertRaises(WDL.Error.WrongArity):
+            self._infer_expr_type("write_tsv([], true)", version="1.1")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._infer_expr_type('write_tsv([], "true")', version="1.2")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._infer_expr_type('write_tsv([["a"]], true)', version="1.2")
+
+        stdlib = LocalStdLib("1.2")
+        expr = WDL.parse_expr(
+            'read_string(write_tsv([{"name":"Alice","lane":"3"},{"name":"Bob","lane":"4"}]))',
+            version="1.2",
+        ).infer_type(WDL.Env.Bindings(), stdlib)
+        self.assertEqual(expr.eval(WDL.Env.Bindings(), stdlib).value, "Alice\t3\nBob\t4")
+
+        expr = WDL.parse_expr(
+            'read_string(write_tsv([{"name":"Alice","lane":"3"},{"name":"Bob","lane":"4"}], true))',
+            version="1.2",
+        ).infer_type(WDL.Env.Bindings(), stdlib)
+        self.assertEqual(
+            expr.eval(WDL.Env.Bindings(), stdlib).value, "name\tlane\nAlice\t3\nBob\t4"
+        )
+
+        expr = WDL.parse_expr(
+            'write_tsv([{"name":"Alice","lane":"3"},{"lane":"4","name":"Bob"}], true)',
+            version="1.2",
+        ).infer_type(WDL.Env.Bindings(), stdlib)
+        with self.assertRaises(WDL.Error.EvalError):
+            expr.eval(WDL.Env.Bindings(), stdlib)
+
+        expr = WDL.parse_expr(
+            'write_tsv([{"name":"Alice","name":"Bob"}], true)',
+            version="1.2",
+        ).infer_type(WDL.Env.Bindings(), stdlib)
+        with self.assertRaises(WDL.Error.EvalError):
+            expr.eval(WDL.Env.Bindings(), stdlib)
 
     def _eval_expr(self, expr: str, env=None, version: str = "development"):
         env = env or WDL.Env.Bindings()
@@ -159,9 +228,7 @@ class TestStdLib(unittest.TestCase):
         ex = WDL.parse_expr(expr, version=version).infer_type(type_env, stdlib)
         return ex.eval(env, stdlib)
 
-    def _infer_expr_type(
-        self, expr: str, env=None, type_env=None, version: str = "development"
-    ):
+    def _infer_expr_type(self, expr: str, env=None, type_env=None, version: str = "development"):
         env = env or WDL.Env.Bindings()
         if type_env is None:
             type_env = WDL.Env.Bindings()
@@ -179,14 +246,14 @@ class TestStdLib(unittest.TestCase):
             self._infer_expr_type("length(xs)", type_env=optional_array_env, version="1.1")
 
         for version in ("1.0", "1.1"):
-            for expr in ('length("abc")', 'length({"a": 1})', 'length(object {a: 1})'):
+            for expr in ('length("abc")', 'length({"a": 1})', "length(object {a: 1})"):
                 with self.subTest(version=version, expr=expr):
                     with self.assertRaises(WDL.Error.StaticTypeMismatch):
                         self._infer_expr_type(expr, version=version)
 
         self.assertEqual(str(self._infer_expr_type('length("abc")', version="1.2")), "Int")
         self.assertEqual(str(self._infer_expr_type('length({"a": 1})', version="1.2")), "Int")
-        self.assertEqual(str(self._infer_expr_type('length(object {a: 1})', version="1.2")), "Int")
+        self.assertEqual(str(self._infer_expr_type("length(object {a: 1})", version="1.2")), "Int")
 
     def test_size_version_gating(self):
         for version in ("1.0", "1.1"):
@@ -241,7 +308,6 @@ class TestStdLib(unittest.TestCase):
         )
         doc.typecheck()
 
-
     def test_stdlib_branch_coverage_length_contains_key(self):
         # length(): wrong arity and optional argument rejection during quantifier checks
         with self.assertRaises(WDL.Error.WrongArity):
@@ -263,30 +329,44 @@ class TestStdLib(unittest.TestCase):
             self._eval_expr("collect_by_key([],[1])", version="1.2")
 
         # contains_key() map variant: optional map & nested keys require String-keyed map
-        tenv = WDL.Env.Bindings().bind("m", WDL.Type.Map((WDL.Type.String(), WDL.Type.Int()), optional=True))
+        tenv = WDL.Env.Bindings().bind(
+            "m", WDL.Type.Map((WDL.Type.String(), WDL.Type.Int()), optional=True)
+        )
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
-            WDL.parse_expr('contains_key(m, "a")', version="1.2").infer_type(tenv, WDL.StdLib.Base("1.2"))
+            WDL.parse_expr('contains_key(m, "a")', version="1.2").infer_type(
+                tenv, WDL.StdLib.Base("1.2")
+            )
 
         tenv = WDL.Env.Bindings().bind("m", WDL.Type.Map((WDL.Type.Int(), WDL.Type.Int())))
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
-            WDL.parse_expr('contains_key(m, ["a"])', version="1.2").infer_type(tenv, WDL.StdLib.Base("1.2"))
+            WDL.parse_expr('contains_key(m, ["a"])', version="1.2").infer_type(
+                tenv, WDL.StdLib.Base("1.2")
+            )
 
         # contains_key() struct/read_json key type checks
         tenv = WDL.Env.Bindings().bind("s", WDL.Type.StructInstance("S", optional=True))
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
-            WDL.parse_expr("contains_key(s, 1)", version="1.2").infer_type(tenv, WDL.StdLib.Base("1.2"))
+            WDL.parse_expr("contains_key(s, 1)", version="1.2").infer_type(
+                tenv, WDL.StdLib.Base("1.2")
+            )
 
         tenv = WDL.Env.Bindings().bind("j", WDL.Type.Any())
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
-            WDL.parse_expr("contains_key(read_json('x.json'), 1)", version="1.2").infer_type(tenv, WDL.StdLib.Base("1.2"))
+            WDL.parse_expr("contains_key(read_json('x.json'), 1)", version="1.2").infer_type(
+                tenv, WDL.StdLib.Base("1.2")
+            )
 
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
             self._eval_expr('contains_key({"a": 1}, [1])', version="1.2")
 
         # runtime nested-key traversal edges
-        self.assertEqual(str(self._eval_expr('contains_key({"a": 1}, ["a", "b"])', version="1.2")), "false")
+        self.assertEqual(
+            str(self._eval_expr('contains_key({"a": 1}, ["a", "b"])', version="1.2")), "false"
+        )
         env = WDL.Env.Bindings().bind("path", WDL.Value.Array(WDL.Type.String(), []))
-        self.assertEqual(str(self._eval_expr('contains_key({"a": 1}, path)', env=env, version="1.2")), "false")
+        self.assertEqual(
+            str(self._eval_expr('contains_key({"a": 1}, path)', env=env, version="1.2")), "false"
+        )
 
     def test_collect_by_key_float_keys(self):
         self.assertEqual(
@@ -313,11 +393,7 @@ class TestStdLib(unittest.TestCase):
             "Array[Pair[Int,Int]]",
         )
         self.assertEqual(
-            str(
-                WDL.parse_expr("zip([1], [2])", version="development")
-                .infer_type([], stdlib)
-                .type
-            ),
+            str(WDL.parse_expr("zip([1], [2])", version="development").infer_type([], stdlib).type),
             "Array[Pair[Int,Int]]+",
         )
 
@@ -325,7 +401,9 @@ class TestStdLib(unittest.TestCase):
         env = WDL.Env.Bindings().bind("sfx", WDL.Value.Null())
         self.assertEqual(str(self._eval_expr('basename("/path/to/file.txt","")')), '"file.txt"')
         self.assertEqual(str(self._eval_expr('basename("file.txt","")')), '"file.txt"')
-        self.assertEqual(str(self._eval_expr('basename("/path/to/file.txt",sfx)', env=env)), '"file.txt"')
+        self.assertEqual(
+            str(self._eval_expr('basename("/path/to/file.txt",sfx)', env=env)), '"file.txt"'
+        )
 
     def test_parse_tsv_row_type(self):
         rows = WDL.StdLib._parse_tsv("alpha\tbeta\n")
@@ -362,7 +440,8 @@ class TestStdLib(unittest.TestCase):
         assert out["e"] == True
         assert out["f"] == False
 
-        self._test_task("""
+        self._test_task(
+            """
         version 1.1
         task test_cmp {
             input {
@@ -374,7 +453,10 @@ class TestStdLib(unittest.TestCase):
                 Boolean a = i <= j
             }
         }
-        """, {"i": 0}, expected_exception=WDL.Error.ValidationError)
+        """,
+            {"i": 0},
+            expected_exception=WDL.Error.ValidationError,
+        )
 
     def test_size_polytype(self):
         tmpl = """
@@ -459,7 +541,7 @@ class TestStdLib(unittest.TestCase):
             ("Float sz = size([])", WDL.Error.StaticTypeMismatch),
             ("Float sz = size({})", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(None)", WDL.Error.StaticTypeMismatch),
-            ("Float sz = size(read_json(\"x.json\"))", WDL.Error.StaticTypeMismatch),
+            ('Float sz = size(read_json("x.json"))', WDL.Error.StaticTypeMismatch),
             ("Float sz = size(dir1,dir2)", WDL.Error.StaticTypeMismatch),
             ("Float sz = size(dir1,[dir2])", WDL.Error.StaticTypeMismatch),
         ]:
@@ -478,7 +560,8 @@ class TestStdLib(unittest.TestCase):
             WDL.StdLib._Size._coerce_paths_argument(WDL.Value.Int(42), WDL.Type.Int())
 
     def test_length_defined_range(self):
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task test_length {
             input {
@@ -493,13 +576,15 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[Int]] ranges = [range(0), range(1), range(3)]
             }
         }
-        """, {"one": 42, "two": 43})
-        self.assertEqual(outputs, {
-            "lengths": [0, 1, 2],
-            "defineds": [True, True, False],
-            "ranges": [[], [0], [0,1,2]]
-        })
-        self._test_task(R"""
+        """,
+            {"one": 42, "two": 43},
+        )
+        self.assertEqual(
+            outputs,
+            {"lengths": [0, 1, 2], "defineds": [True, True, False], "ranges": [[], [0], [0, 1, 2]]},
+        )
+        self._test_task(
+            R"""
         version 1.0
         task bogus {
             command {}
@@ -507,8 +592,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] bogus = range(-42)
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
-
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
         with self.assertRaises(WDL.Error.WrongArity):
             self._eval_expr("length([1], [2])", version="1.2")
@@ -553,7 +639,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["object_len"], 2)
 
         # Error: Structs aren't in the WDL 1.2 length() signature
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         struct Person {
             String first
@@ -573,7 +660,9 @@ class TestStdLib(unittest.TestCase):
                 Int struct_len = length(p)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Test length(read_json()) on array
         outputs = self._test_task(R"""
@@ -590,7 +679,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["len"], 5)
 
         # Error: None isn't a valid dynamic length() argument
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -598,7 +688,9 @@ class TestStdLib(unittest.TestCase):
                 Int len = length(None)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Test length(read_json()) on object
         outputs = self._test_task(R"""
@@ -646,7 +738,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs, {"ans": [3, -3, 43, 43]})
 
         # regression test issue #698
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.1
 
         task test_round {
@@ -664,7 +757,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Boolean] all_true = [round(f1) == i1, round(f2) == i2]
             }
         }
-        """, {"i1": 42})
+        """,
+            {"i1": 42},
+        )
         self.assertEqual(outputs, {"all_true": [True, True]})
 
     def test_basename_prefix(self):
@@ -687,14 +782,18 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outputs, {
-            "ans": ["file.txt", "file.txt", "file.txt", "file", "file.sam"],
-            "env_param": ["-e key1=value1", "-e key2=value2", "-e key3=value3"],
-            "env2_param": ["-f 1", "-f 2", "-f 3"]
-        })
+        self.assertEqual(
+            outputs,
+            {
+                "ans": ["file.txt", "file.txt", "file.txt", "file", "file.sam"],
+                "env_param": ["-e key1=value1", "-e key2=value2", "-e key3=value3"],
+                "env2_param": ["-f 1", "-f 2", "-f 3"],
+            },
+        )
 
     def test_select(self):
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task test_select {
             input {
@@ -713,16 +812,22 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[Int]] all2 = select_all([three])
             }
         }
-        """, {"one": [1], "two": [2]})
-        self.assertEqual(outputs, {
-            "first1": [1],
-            "first2": [2],
-            "first3": [2],
-            "first4": [2],
-            "all1": [[1],[2]],
-            "all2": []
-        })
-        outputs = self._test_task(R"""
+        """,
+            {"one": [1], "two": [2]},
+        )
+        self.assertEqual(
+            outputs,
+            {
+                "first1": [1],
+                "first2": [2],
+                "first3": [2],
+                "first4": [2],
+                "all1": [[1], [2]],
+                "all2": [],
+            },
+        )
+        outputs = self._test_task(
+            R"""
         version 1.0
         task test_select {
             input {
@@ -733,9 +838,12 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] bogus = select_first([one])
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         self.assertTrue("given empty or all-null array" in str(outputs))
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task test_select {
             input {
@@ -745,8 +853,11 @@ class TestStdLib(unittest.TestCase):
                 Int bogus = select_first([])
             }
         }
-        """, expected_exception=WDL.Error.IndeterminateType)
-        outputs = self._test_task(R"""
+        """,
+            expected_exception=WDL.Error.IndeterminateType,
+        )
+        outputs = self._test_task(
+            R"""
         version 1.0
         task test_select {
             input {
@@ -756,7 +867,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] bogus = select_all([])
             }
         }
-        """, expected_exception=WDL.Error.IndeterminateType)
+        """,
+            expected_exception=WDL.Error.IndeterminateType,
+        )
 
     def test_select_first_default(self):
         self.assertEqual(str(self._eval_expr("select_first([], 5)", version="1.2")), "5")
@@ -830,14 +943,17 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outputs, {
-            "chocolike": "I like chocolate when it's late",
-            "chocolove": "I love chocolate when it's late",
-            "chocoearly": "I like chocoearly when it's early",
-            "chocolate": "I like chocolate when it's early",
-            "chocoearlylate": "I like chocearly when it's late",
-            "choco4": "I 4444 chocolate 4444 it's late"
-        })
+        self.assertEqual(
+            outputs,
+            {
+                "chocolike": "I like chocolate when it's late",
+                "chocolove": "I love chocolate when it's late",
+                "chocoearly": "I like chocoearly when it's early",
+                "chocolate": "I like chocolate when it's early",
+                "chocoearlylate": "I like chocearly when it's late",
+                "choco4": "I 4444 chocolate 4444 it's late",
+            },
+        )
         outputs = self._test_task(R"""
         task example {
             input {
@@ -853,22 +969,21 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         self.assertTrue(outputs["outputFile"].endswith("my_input_file.index"))
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         task bogus {
             command {}
             output {
                 String bogus = sub("foo", "(()", "bar")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_find_matches(self):
-        self.assertEqual(
-            self._eval_expr('find("hello world", "e..o")', version="1.2").json, "ello"
-        )
-        self.assertIsNone(
-            self._eval_expr('find("hello world", "goodbye")', version="1.2").json
-        )
+        self.assertEqual(self._eval_expr('find("hello world", "e..o")', version="1.2").json, "ello")
+        self.assertIsNone(self._eval_expr('find("hello world", "goodbye")', version="1.2").json)
         self.assertEqual(
             self._eval_expr(R"""find("hello\tBob", "\\t")""", version="1.2").json, "\t"
         )
@@ -880,9 +995,7 @@ class TestStdLib(unittest.TestCase):
 
         self.assertTrue(self._eval_expr('matches("sample_R1.fastq", "_R1")', version="1.2").json)
         self.assertFalse(
-            self._eval_expr(
-                'matches("sample_R1.fastq", "\\\\.(gz|zip|zstd)")', version="1.2"
-            ).json
+            self._eval_expr('matches("sample_R1.fastq", "\\\\.(gz|zip|zstd)")', version="1.2").json
         )
         self.assertTrue(self._eval_expr('matches("abc123", "^a.+3$")', version="1.2").json)
         self.assertFalse(self._eval_expr('matches("abc123", "^a.+2$")', version="1.2").json)
@@ -915,11 +1028,14 @@ class TestStdLib(unittest.TestCase):
         """)
         self.assertEqual(outputs["ai"], [1, 2, 3, 1, 21, 22])
         self.assertEqual(outputs["af"], ["/tmp/X.txt", "/tmp/Y.txt", "/tmp/Z.txt"])
-        self.assertEqual(outputs["ap"], [
-            {"left": 0.1, "right": "mouse"},
-            {"left": 3, "right": "cat"},
-            {"left": 15, "right": "dog"}
-        ])
+        self.assertEqual(
+            outputs["ap"],
+            [
+                {"left": 0.1, "right": "mouse"},
+                {"left": 3, "right": "cat"},
+                {"left": 15, "right": "dog"},
+            ],
+        )
 
     def test_size(self):
         with open(os.path.join(self._dir, "alyssa.txt"), "w") as outfile:
@@ -940,7 +1056,8 @@ class TestStdLib(unittest.TestCase):
         )
         with open(os.path.join(self._dir, "dir2", "sub", "bob.txt"), "w") as outfile:
             outfile.write("Bob\n")
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.2
         struct PathStruct {
             File file
@@ -992,18 +1109,24 @@ class TestStdLib(unittest.TestCase):
                 Float duplicate_dir_size = size([dir1, dir1], "B")
             }
         }
-        """, {"files": [ os.path.join(self._dir, "alyssa.txt"),
-                         os.path.join(self._dir, "ben.txt") ],
-              "dir1": os.path.join(self._dir, "dir1"),
-              "dir2": os.path.join(self._dir, "dir2")})
+        """,
+            {
+                "files": [
+                    os.path.join(self._dir, "alyssa.txt"),
+                    os.path.join(self._dir, "ben.txt"),
+                ],
+                "dir1": os.path.join(self._dir, "dir1"),
+                "dir2": os.path.join(self._dir, "dir2"),
+            },
+        )
         self.assertEqual(len(outputs["sizes"]), 6)
         self.assertEqual(outputs["sizes"][0], 7)
         self.assertEqual(outputs["sizes"][1], 11)
-        self.assertAlmostEqual(outputs["sizes"][2], 7/1000000)
-        self.assertAlmostEqual(outputs["sizes"][3], 7/1048576)
-        self.assertAlmostEqual(outputs["sizes"][4], 11/1000000000)
-        self.assertAlmostEqual(outputs["sizes"][5], 11/1073741824)
-        self.assertAlmostEqual(outputs["size2"], 11/1024)
+        self.assertAlmostEqual(outputs["sizes"][2], 7 / 1000000)
+        self.assertAlmostEqual(outputs["sizes"][3], 7 / 1048576)
+        self.assertAlmostEqual(outputs["sizes"][4], 11 / 1000000000)
+        self.assertAlmostEqual(outputs["sizes"][5], 11 / 1073741824)
+        self.assertAlmostEqual(outputs["size2"], 11 / 1024)
         self.assertEqual(outputs["legacy_array_string_size"], 11)
         self.assertEqual(outputs["nosize1"], 0)
         self.assertEqual(outputs["nosize2"], 7)
@@ -1020,15 +1143,19 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["duplicate_file_size"], 14)
         self.assertEqual(outputs["duplicate_dir_size"], 28)
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task hello {
             Float x = size("/etc/passwd")
             command {}
         }
-        """, expected_exception=WDL.Error.InputError)
+        """,
+            expected_exception=WDL.Error.InputError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task hello {
             command {}
@@ -1036,9 +1163,12 @@ class TestStdLib(unittest.TestCase):
                 Float x = size("/etc/passwd")
             }
         }
-        """, expected_exception=WDL.runtime.task.OutputError)
+        """,
+            expected_exception=WDL.runtime.task.OutputError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task hello {
             command {
@@ -1048,7 +1178,9 @@ class TestStdLib(unittest.TestCase):
                 Float x = size("foo", "bogus")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_glob(self):
         outputs = self._test_task(R"""
@@ -1086,7 +1218,8 @@ class TestStdLib(unittest.TestCase):
                 assert os.path.isfile(fn), fn
         self.assertTrue(outputs["f1"].endswith("/foo"))
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task hello {
             command {}
@@ -1094,9 +1227,12 @@ class TestStdLib(unittest.TestCase):
                 Array[File] filez = glob("/etc/passwd")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task hello {
             command {}
@@ -1104,7 +1240,9 @@ class TestStdLib(unittest.TestCase):
                 Array[File] filez = glob("../../etc/passwd")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_concat(self):
         outputs = self._test_task(R"""
@@ -1136,7 +1274,8 @@ class TestStdLib(unittest.TestCase):
     def test_read(self):
         with open(os.path.join(self._dir, "strings.txt"), "w") as outfile:
             outfile.write("foo\nbar\nbas\n")
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task hello {
             input {
@@ -1175,7 +1314,9 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] o_map = read_map("map.txt")
             }
         }
-        """, {"strings": os.path.join(self._dir, "strings.txt")})
+        """,
+            {"strings": os.path.join(self._dir, "strings.txt")},
+        )
         self.assertEqual(outputs["i_strings_string"], "foo\nbar\nbas")
         self.assertEqual(outputs["o_strings_string"], "foo\nbar\nbas")
         self.assertEqual(outputs["o_names_string"], "Alyssa\nBen")
@@ -1230,7 +1371,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["first"], {"name": "Alice", "lane": "3", "barcode": "GATTACA"})
         self.assertEqual(outputs["empty"], [])
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         task test {
             command {}
@@ -1238,9 +1380,12 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[String]] table = read_tsv("samples.tsv", false)
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task test {
             command {}
@@ -1248,9 +1393,12 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[String]] table = read_tsv("samples.tsv", false)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task test {
             input {
@@ -1261,9 +1409,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[String]] table = read_tsv("samples.tsv", header)
             }
         }
-        """, {"header": False}, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            {"header": False},
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task test {
             command <<<
@@ -1273,7 +1425,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Map[String, String]] samples = read_tsv("samples.tsv", false, ["name", "name"])
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_read_json(self):
         outputs = self._test_task(R"""
@@ -1328,7 +1482,8 @@ class TestStdLib(unittest.TestCase):
         """)
         self.assertEqual(outputs["my_array"], ["foo", "bar"])
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task test {
             command <<<
@@ -1338,9 +1493,12 @@ class TestStdLib(unittest.TestCase):
                 Array[String] my_array = read_json(stdout())
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         struct Point {
             Int x
@@ -1356,7 +1514,9 @@ class TestStdLib(unittest.TestCase):
             output {
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
         outputs = self._test_task(R"""
         version 1.0
@@ -1371,7 +1531,8 @@ class TestStdLib(unittest.TestCase):
         """)
         self.assertEqual(outputs["my_map"], {"foo": "bar"})
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task test {
             command <<<
@@ -1381,9 +1542,12 @@ class TestStdLib(unittest.TestCase):
                 Map[String, String] my_map = read_json(stdout())
             }
         }
-        """, expected_exception=WDL.Error.InputError)
+        """,
+            expected_exception=WDL.Error.InputError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task test {
             command <<<
@@ -1393,7 +1557,9 @@ class TestStdLib(unittest.TestCase):
                 String baz = read_json(stdout())["baz"]
             }
         }
-        """, expected_exception=WDL.Error.OutOfBounds)
+        """,
+            expected_exception=WDL.Error.OutOfBounds,
+        )
 
     def test_read_map_ints(self):
         outputs = self._test_task(R"""
@@ -1519,7 +1685,10 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         self.assertEqual(dict(**alice, lab=None), outputs["alice"])
-        self.assertEqual({"samples": [dict(**alice, lab=None), dict(**bob, lab="Biohub")]}, outputs["samplesheet2"])
+        self.assertEqual(
+            {"samples": [dict(**alice, lab=None), dict(**bob, lab="Biohub")]},
+            outputs["samplesheet2"],
+        )
 
     def test_struct_from_read_json_with_extra_keys(self):
         outputs = self._test_task(R"""
@@ -1540,9 +1709,12 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outputs["samples"], [{"name": "Alice"}, {"name": "Rishi"}, {"name": "Harry"}])
+        self.assertEqual(
+            outputs["samples"], [{"name": "Alice"}, {"name": "Rishi"}, {"name": "Harry"}]
+        )
 
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         struct Sample {
             String name
@@ -1556,12 +1728,18 @@ class TestStdLib(unittest.TestCase):
                 Array[Sample] samples2 = read_json(write_json(samples))
             }
         }
-        """, {"samples": [
-            {"name": "Alice"},
-            {"name": "Rishi", "address": "10 Downing St", "city": "Westminster"},
-            {"name": "Harry", "address": "4 Privet Drive"}
-        ]})
-        self.assertEqual(outputs["samples2"], [{"name": "Alice"}, {"name": "Rishi"}, {"name": "Harry"}])
+        """,
+            {
+                "samples": [
+                    {"name": "Alice"},
+                    {"name": "Rishi", "address": "10 Downing St", "city": "Westminster"},
+                    {"name": "Harry", "address": "4 Privet Drive"},
+                ]
+            },
+        )
+        self.assertEqual(
+            outputs["samples2"], [{"name": "Alice"}, {"name": "Rishi"}, {"name": "Harry"}]
+        )
 
     def test_issue524(self):
         # additional cases for struct initialization from read_json(), motivated by issue #524
@@ -1623,9 +1801,10 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outp["data"], {"x": 3.14159, "y": None, "z": [4,2,None]})
+        self.assertEqual(outp["data"], {"x": 3.14159, "y": None, "z": [4, 2, None]})
         # unusable null
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
 
         struct MyStruct {
@@ -1652,7 +1831,9 @@ class TestStdLib(unittest.TestCase):
                 MyStruct data = read_json("data.json")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         # top-level null
         outp = self._test_task(R"""
         version 1.0
@@ -1678,7 +1859,8 @@ class TestStdLib(unittest.TestCase):
         """)
         self.assertEqual(outp, {"data": None})
         # coercion failure -- required member missing
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
 
         struct MyStruct {
@@ -1704,9 +1886,12 @@ class TestStdLib(unittest.TestCase):
                 MyStruct data = read_json("data.json")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         # bad coercion to Map (key type)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
 
         struct MyStruct {
@@ -1732,9 +1917,12 @@ class TestStdLib(unittest.TestCase):
                 Map[Float,String] data = read_json("data.json")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         # bad coercion to Map (value type)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
 
         struct MyStruct {
@@ -1760,7 +1948,9 @@ class TestStdLib(unittest.TestCase):
                 Map[String,Float] data = read_json("data.json")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_issue538(self):
         # more struct init regression
@@ -1779,11 +1969,12 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outp["result"], {"map": {"foo":"bar", "fizz":"buzz"}})
+        self.assertEqual(outp["result"], {"map": {"foo": "bar", "fizz": "buzz"}})
 
     def test_issue563(self):
         # still more struct init regression
-        outp = self._test_task(R"""
+        outp = self._test_task(
+            R"""
         version 1.0
         struct Foo {
             Int x
@@ -1798,7 +1989,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Foo] out = select_all([i, j])
             }
         }
-        """, {"j": {"x": 0}})
+        """,
+            {"j": {"x": 0}},
+        )
         self.assertEqual(outp, {"out": [{"x": 0}]})
 
     def test_issue580(self):
@@ -1879,7 +2072,10 @@ class TestStdLib(unittest.TestCase):
                 }
             }""")
         except Exception as exn:
-            self.assertTrue("unusable runtime struct initializer, no such member(s) in struct Readgroup: R1_md5 R2_md5" in str(exn))
+            self.assertTrue(
+                "unusable runtime struct initializer, no such member(s) in struct Readgroup: R1_md5 R2_md5"
+                in str(exn)
+            )
 
         # slightly simpler version covering a different exception handling path (#1)
         try:
@@ -1946,7 +2142,10 @@ class TestStdLib(unittest.TestCase):
                 }
             }""")
         except Exception as exn:
-            self.assertTrue("unusable runtime struct initializer, no such member(s) in struct Readgroup: R1_md5 R2_md5" in str(exn))
+            self.assertTrue(
+                "unusable runtime struct initializer, no such member(s) in struct Readgroup: R1_md5 R2_md5"
+                in str(exn)
+            )
 
         # slightly simpler version covering a different exception handling path (#2)
         try:
@@ -2038,7 +2237,9 @@ class TestStdLib(unittest.TestCase):
                 }
             }""")
         except Exception as exn:
-            self.assertTrue("runtime type mismatch initializing Int count member of struct Sample" in str(exn))
+            self.assertTrue(
+                "runtime type mismatch initializing Int count member of struct Sample" in str(exn)
+            )
 
         # unifying arrays of structs with optional members
         outp = self._test_task(R"""
@@ -2124,11 +2325,15 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual("wgs1-paired-end", outp["control1"])
         self.assertEqual(None, outp["gender0"])
         self.assertEqual(None, outp["gender1"])
-        self.assertEqual("537ffc52342314d839e7fdd91bbdccd0", outp["data"]["samples"][1]["readgroups"][0]["R2_md5"])
+        self.assertEqual(
+            "537ffc52342314d839e7fdd91bbdccd0",
+            outp["data"]["samples"][1]["readgroups"][0]["R2_md5"],
+        )
         self.assertEqual(None, outp["data"]["samples"][1]["readgroups"][1]["R2_md5"])
 
     def test_bad_object(self):
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2138,9 +2343,12 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] map = read_object("empty")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2150,9 +2358,12 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] map = read_object("dup")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2163,9 +2374,12 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] map = read_object("ragged")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         struct Sample {
             String name
@@ -2182,10 +2396,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Sample] samplesheet2 = read_objects("samplesheet2.txt")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_boolean(self):
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2195,7 +2412,9 @@ class TestStdLib(unittest.TestCase):
                 Boolean b = read_boolean("bool")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
         outp = self._test_task(R"""
         version 1.0
@@ -2249,15 +2468,19 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["o_map"], {"key1": "value1", "key2": "value2"})
 
     def test_bad_map(self):
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             File map = write_map({"foo": "bar\t"})
             command {}
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2268,9 +2491,12 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] map = read_map("map.txt")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad_map {
             command <<<
@@ -2281,7 +2507,9 @@ class TestStdLib(unittest.TestCase):
                 Map[String,String] map = read_map("map.txt")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_transpose(self):
         outputs = self._test_task(R"""
@@ -2295,7 +2523,8 @@ class TestStdLib(unittest.TestCase):
         """)
         self.assertEqual(outputs["mat"], [[0, 3], [1, 4], [2, 5]])
 
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task hello {
             command {}
@@ -2303,7 +2532,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Array[Int]] mat = transpose([[0, 1, 2], [3, 4, 5], []])
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_zip_cross(self):
         outputs = self._test_task(R"""
@@ -2319,21 +2550,24 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outputs["zipped"], [
-            {"left": 1, "right": "a"},
-            {"left": 2, "right": "b"},
-            {"left": 3, "right": "c"}
-        ])
-        self.assertEqual(outputs["crossed"], [
-            {"left": 1, "right": "d"},
-            {"left": 1, "right": "e"},
-            {"left": 2, "right": "d"},
-            {"left": 2, "right": "e"},
-            {"left": 3, "right": "d"},
-            {"left": 3, "right": "e"}
-        ])
+        self.assertEqual(
+            outputs["zipped"],
+            [{"left": 1, "right": "a"}, {"left": 2, "right": "b"}, {"left": 3, "right": "c"}],
+        )
+        self.assertEqual(
+            outputs["crossed"],
+            [
+                {"left": 1, "right": "d"},
+                {"left": 1, "right": "e"},
+                {"left": 2, "right": "d"},
+                {"left": 2, "right": "e"},
+                {"left": 3, "right": "d"},
+                {"left": 3, "right": "e"},
+            ],
+        )
 
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task hello {
             Array[Int] xs = [ 1, 2, 3 ]
@@ -2344,7 +2578,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Pair[Int, String]] zipped = zip(xs, zs)
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
     def test_unzip(self):
         outputs = self._test_task(R"""
@@ -2360,16 +2596,14 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """)
-        self.assertEqual(outputs["unzipped"], {
-            "left": [1, 2, 3],
-            "right": ["a", "b", "c"]
-        })
-        self.assertEqual(outputs["uncrossed"], {
-            "left": [1, 1, 2, 2, 3, 3],
-            "right": ["d", "e", "d", "e", "d", "e"]
-        })
+        self.assertEqual(outputs["unzipped"], {"left": [1, 2, 3], "right": ["a", "b", "c"]})
+        self.assertEqual(
+            outputs["uncrossed"],
+            {"left": [1, 1, 2, 2, 3, 3], "right": ["d", "e", "d", "e", "d", "e"]},
+        )
 
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version 1.0
         task hello {
             input {
@@ -2380,7 +2614,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Pair[Int, Int]] zipped = unzip(x)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
     def test_sep(self):
         outputs = self._test_task(R"""
@@ -2428,9 +2664,8 @@ class TestStdLib(unittest.TestCase):
                 String out = read_string(stdout())
             }
         }
-        """) #, expected_exception=WDL.Error.SyntaxError)
+        """)  # , expected_exception=WDL.Error.SyntaxError)
         self.assertEqual("value1,value2,value3", outputs["out"])
-
 
     def test_suffix(self):
         outputs = self._test_task(R"""
@@ -2446,11 +2681,17 @@ class TestStdLib(unittest.TestCase):
         """)
 
         # Check to make sure suffix added to each element in array
-        self.assertEqual(outputs, {
-            "chocolike": "I like chocolate when it's late",
-            "chocolove": ["I like chocolate when it's late and early"],
-            "chocoearly": ["I like chocolate when it's late and early","I like chocolate when it's late and early"]
-        })
+        self.assertEqual(
+            outputs,
+            {
+                "chocolike": "I like chocolate when it's late",
+                "chocolove": ["I like chocolate when it's late and early"],
+                "chocoearly": [
+                    "I like chocolate when it's late and early",
+                    "I like chocolate when it's late and early",
+                ],
+            },
+        )
 
         # check to make sure coercible type returns appropriate suffix
         outputs = self._test_task(R"""
@@ -2465,7 +2706,8 @@ class TestStdLib(unittest.TestCase):
                 """)
 
         # Missing Suffix
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task test_suffix {
             command {}
@@ -2473,10 +2715,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] integers = suffix([1,2,3,4])
             }
         }
-        """,expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Suffix should require an array
-        self._test_task(R"""
+        self._test_task(
+            R"""
                 version 1.0
                 task test_suffix {
                     command {}
@@ -2484,10 +2729,11 @@ class TestStdLib(unittest.TestCase):
                         Array[Int] integers = suffix("not-allowed","s")
                     }
                 }
-                """, expected_exception=WDL.Error.StaticTypeMismatch)
+                """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
-        self.assertEqual(outputs["integers_with_suffix"], ["1.0","2.0","3.0","4.0"])
-
+        self.assertEqual(outputs["integers_with_suffix"], ["1.0", "2.0", "3.0", "4.0"])
 
     def test_quote(self):
         outputs = self._test_task(R"""
@@ -2501,10 +2747,10 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         # Check to make sure each element has be quoted appropriately
-        self.assertEqual(outputs, {
-            "arguments": ["foo","bar","baz"],
-            "quoted_args": ["\"foo\"","\"bar\"","\"baz\""]
-        })
+        self.assertEqual(
+            outputs,
+            {"arguments": ["foo", "bar", "baz"], "quoted_args": ['"foo"', '"bar"', '"baz"']},
+        )
 
         outputs = self._test_task(R"""
         version development
@@ -2518,13 +2764,11 @@ class TestStdLib(unittest.TestCase):
         """)
 
         # Check to make sure each element has been coerced and quoted appropriately
-        self.assertEqual(outputs, {
-            "arguments": [1,2,3],
-            "quoted_args": ["\"1\"","\"2\"","\"3\""]
-        })
+        self.assertEqual(outputs, {"arguments": [1, 2, 3], "quoted_args": ['"1"', '"2"', '"3"']})
 
         # Check invalid type does not work
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version development
         task test_quote {
             command {}
@@ -2533,10 +2777,13 @@ class TestStdLib(unittest.TestCase):
                 Array[String] quoted_args = quote(arguments)
             }
         }
-        """,expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # check unavailable in WDL draft-2 and 1.0
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task test_quote {
             command {}
@@ -2545,8 +2792,9 @@ class TestStdLib(unittest.TestCase):
                 Array[String] quoted_args = quote(arguments) # ["\"1\"","\"2\"","\"3\""]
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
-
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
     def test_squote(self):
         outputs = self._test_task(R"""
@@ -2560,10 +2808,10 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         # Check to make sure each element has be quoted appropriately
-        self.assertEqual(outputs, {
-            "arguments": ["foo","bar","baz"],
-            "quoted_args": ["'foo'","'bar'","'baz'"]
-        })
+        self.assertEqual(
+            outputs,
+            {"arguments": ["foo", "bar", "baz"], "quoted_args": ["'foo'", "'bar'", "'baz'"]},
+        )
 
         outputs = self._test_task(R"""
         version development
@@ -2577,13 +2825,11 @@ class TestStdLib(unittest.TestCase):
         """)
 
         # Check to make sure each element has been coerced and quoted appropriately
-        self.assertEqual(outputs, {
-            "arguments": [1,2,3],
-            "quoted_args": ["'1'","'2'","'3'"]
-        })
+        self.assertEqual(outputs, {"arguments": [1, 2, 3], "quoted_args": ["'1'", "'2'", "'3'"]})
 
         # Check invalid type does not work
-        outputs = self._test_task(R"""
+        outputs = self._test_task(
+            R"""
         version development
         task test_squote {
             command {}
@@ -2592,7 +2838,9 @@ class TestStdLib(unittest.TestCase):
                 Array[String] quoted_args = squote(arguments)
             }
         }
-        """,expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
     def test_keys(self):
         outputs = self._test_task(R"""
@@ -2613,7 +2861,7 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         self.assertEqual(outputs["k1"], ["a", "c"])
-        self.assertEqual(outputs["k2"], [1,-1])
+        self.assertEqual(outputs["k2"], [1, -1])
         self.assertEqual(outputs["k4"], [])
         self.assertEqual(outputs["k5"], [{"left": 1, "right": False}, {"left": 3, "right": True}])
 
@@ -2679,7 +2927,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["contact_keys"], ["name", "email", "phone"])
 
         # Error: keys(Struct) not available in WDL 1.1
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         struct Person {
             String first
@@ -2697,10 +2946,13 @@ class TestStdLib(unittest.TestCase):
                 Array[String] k = keys(p)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: optional Map argument
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             input {
@@ -2711,10 +2963,13 @@ class TestStdLib(unittest.TestCase):
                 Array[String] k = keys(m)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: optional Struct argument
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         struct Person {
             String first
@@ -2732,7 +2987,9 @@ class TestStdLib(unittest.TestCase):
                 Array[String] k = keys(p)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Test keys() with read_json coerced to Map
         outputs = self._test_task(R"""
@@ -2786,7 +3043,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(sorted(outputs["json_keys"]), ["x", "y", "z"])
 
         # Error: direct keys(read_json()) is WDL 1.2+ behavior
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         task bad {
             command <<<
@@ -2796,10 +3054,13 @@ class TestStdLib(unittest.TestCase):
                 Array[String] json_keys = keys(read_json("data.json"))
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: arbitrary Any expressions aren't accepted; only direct read_json()
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command <<<
@@ -2809,10 +3070,13 @@ class TestStdLib(unittest.TestCase):
                 Array[String] json_keys = keys(if true then read_json("data.json") else read_json("data.json"))
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: keys(read_json()) with non-object JSON raises EvalError
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command <<<
@@ -2822,7 +3086,9 @@ class TestStdLib(unittest.TestCase):
                 Array[String] json_keys = keys(read_json("data.json"))
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
 
         # Note: The fallback path for Type.Object (line 1125-1126 in StdLib.py) is defensive code
         # that may be hit during coercion from read_json, though it's hard to isolate in testing.
@@ -2876,7 +3142,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["vals"], [[1, 2], [3, 4, 5]])
 
         # Error: wrong arity (too few arguments)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -2884,10 +3151,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] x = values()
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Error: wrong arity (too many arguments)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -2895,10 +3165,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] x = values({"a": 1}, {"b": 2})
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Error: not available in WDL 1.1
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         task bad {
             command {}
@@ -2906,10 +3179,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] x = values({"a": 1})
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
         # Error: not available in WDL 1.0
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad {
             command {}
@@ -2917,10 +3193,13 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] x = values({"a": 1})
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
         # Error: first argument not a map
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -2928,7 +3207,9 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] x = values([1, 2, 3])
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
     def test_map_pairs(self):
         outputs = self._test_task(R"""
@@ -2956,11 +3237,32 @@ class TestStdLib(unittest.TestCase):
         }
         """)
         self.assertEqual(outputs["xmap_out"], {"b": 1, "a": 2, "c": 3})
-        self.assertEqual(outputs["ymap_out"], {"a": {"left": "a.bam", "right": "a.bai"}, "b": {"left": "b.bam", "right": "b.bai"}})
+        self.assertEqual(
+            outputs["ymap_out"],
+            {"a": {"left": "a.bam", "right": "a.bai"}, "b": {"left": "b.bam", "right": "b.bai"}},
+        )
         self.assertEqual(outputs["xmulti"], {"b": [1], "a": [2], "c": [3]})
-        self.assertEqual(outputs["ymulti"], {"a": [{"left": "a_1.bam", "right": "a_1.bai"}, {"left": "a_2.bam", "right": "a_2.bai"}], "b": [{"left": "b.bam", "right": "b.bai"}]})
-        self.assertEqual(outputs["x_roundtrip"], [{"left": "b", "right": 1}, {"left": "a", "right": 2}, {"left": "c", "right": 3}])
-        self.assertEqual(outputs["y_roundtrip"], [{"left": "a", "right": {"left": "a.bam", "right": "a.bai"}}, {"left": "b", "right": {"left": "b.bam", "right": "b.bai"}}])
+        self.assertEqual(
+            outputs["ymulti"],
+            {
+                "a": [
+                    {"left": "a_1.bam", "right": "a_1.bai"},
+                    {"left": "a_2.bam", "right": "a_2.bai"},
+                ],
+                "b": [{"left": "b.bam", "right": "b.bai"}],
+            },
+        )
+        self.assertEqual(
+            outputs["x_roundtrip"],
+            [{"left": "b", "right": 1}, {"left": "a", "right": 2}, {"left": "c", "right": 3}],
+        )
+        self.assertEqual(
+            outputs["y_roundtrip"],
+            [
+                {"left": "a", "right": {"left": "a.bam", "right": "a.bai"}},
+                {"left": "b", "right": {"left": "b.bam", "right": "b.bai"}},
+            ],
+        )
 
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
             self._test_task(R"""
@@ -3056,7 +3358,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["no_pair"], False)
 
         # Error: wrong arity (too few arguments)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3064,10 +3367,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2])
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Error: wrong arity (too many arguments)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3075,10 +3381,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2], 1, 2)
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Error: not available in WDL 1.1
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         task bad {
             command {}
@@ -3086,10 +3395,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2], 1)
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
         # Error: not available in WDL 1.0
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.0
         task bad {
             command {}
@@ -3097,10 +3409,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2], 1)
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
         # Error: type mismatch (String in Int array)
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3108,10 +3423,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2], "string")
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: first argument not an array
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3119,7 +3437,9 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains("not an array", "x")
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Optional element types: Array[T?] with T, T?, and None
         outputs = self._test_task(R"""
@@ -3146,7 +3466,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["has_null"], True)
 
         # Error: optional value in non-optional array
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             input {
@@ -3157,7 +3478,9 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains([1, 2, 3], maybe_num)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
     def test_chunk(self):
         """Test the chunk() function from WDL 1.2"""
@@ -3187,9 +3510,7 @@ class TestStdLib(unittest.TestCase):
             array = list(range(length))
             array_literal = "[" + ", ".join(str(i) for i in array) + "]"
             for chunk_size in range(1, length + 2):
-                expected = [
-                    array[i : i + chunk_size] for i in range(0, length, chunk_size)
-                ] or [[]]
+                expected = [array[i : i + chunk_size] for i in range(0, length, chunk_size)] or [[]]
                 self.assertEqual(
                     self._eval_expr(f"chunk({array_literal}, {chunk_size})", version="1.2").json,
                     expected,
@@ -3376,7 +3697,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["has_a_z"], False)
 
         # Error: arbitrary Any expressions aren't accepted; only direct read_json()
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command <<<
@@ -3386,10 +3708,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(if true then read_json("data.json") else read_json("data.json"), "x")
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: wrong arity
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3397,10 +3722,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key({"a": 1})
             }
         }
-        """, expected_exception=WDL.Error.WrongArity)
+        """,
+            expected_exception=WDL.Error.WrongArity,
+        )
 
         # Error: not available in WDL 1.1
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.1
         task bad {
             command {}
@@ -3408,10 +3736,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key({"a": 1}, "a")
             }
         }
-        """, expected_exception=WDL.Error.NoSuchFunction)
+        """,
+            expected_exception=WDL.Error.NoSuchFunction,
+        )
 
         # Error: key type mismatch
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             input {
@@ -3422,7 +3753,9 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(m, "one")
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: None key only allowed when the map key type is optional
         optional_key_wdl = R"""
@@ -3453,7 +3786,6 @@ class TestStdLib(unittest.TestCase):
         )
         self.assertIsInstance(expr.type, WDL.Type.Boolean)
 
-
         # Error: optional map not allowed when check_quant=True
         optional_map_wdl = R"""
         version 1.2
@@ -3471,7 +3803,8 @@ class TestStdLib(unittest.TestCase):
             WDL.parse_document(optional_map_wdl).typecheck()
 
         # Error: nested key paths on maps require String keys
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             input {
@@ -3482,10 +3815,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(m, ["1"])
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: struct/object lookup key must be String or Array[String]
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         struct Box {
             Int v
@@ -3499,10 +3835,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(b, 1)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: contains_key(read_json()) key must be String or Array[String]
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command <<<
@@ -3512,10 +3851,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(read_json("data.json"), 1)
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: nested key array must be Array[String]
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             input {
@@ -3526,7 +3868,9 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(m, [1])
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Runtime: nested lookup falls through non-collection intermediates
         outputs = self._test_task(R"""
@@ -3557,7 +3901,8 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["has_empty"], False)
 
         # Error: first argument not a collection
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command {}
@@ -3565,10 +3910,13 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key("not a map", "key")
             }
         }
-        """, expected_exception=WDL.Error.StaticTypeMismatch)
+        """,
+            expected_exception=WDL.Error.StaticTypeMismatch,
+        )
 
         # Error: contains_key(read_json()) with non-collection JSON
-        self._test_task(R"""
+        self._test_task(
+            R"""
         version 1.2
         task bad {
             command <<<
@@ -3578,4 +3926,6 @@ class TestStdLib(unittest.TestCase):
                 Boolean x = contains_key(read_json("data.json"), "key")
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )


### PR DESCRIPTION
### Motivation
- Add WDL 1.2-compliant `write_tsv()` signatures so `write_tsv` accepts `Array[Map[String,String]]` rows with an optional header flag while preserving the legacy `Array[Array[String]]` behavior.
- Perform type/version gating and provide clear eval-time errors for unsupported argument combinations to match spec semantics.

### Description
- Replace the old static `write_tsv(Array[Array[String]])` registration with a polymorphic `_WriteTsv` `EagerFunction` and assign it as `self.write_tsv` in `WDL/StdLib.py` so the function can implement WDL 1.2-specific infer/type and runtime behavior.
- Add `_serialize_tsv_objects()` in `WDL/StdLib.py` to serialize `Array[Map[String,String]]` into TSV with optional header emission and validations for unique and consistent object keys across rows.
- Implement `infer_type` and `_call_eager` in `_WriteTsv` to enforce arity, version gating, and argument-type checks (including rejecting `write_tsv(Array[Array[String]], Boolean)`), and to dispatch to the appropriate serializer at runtime.
- Add unit tests in `tests/test_5stdlib.py` (`test_write_tsv_unit_branches`) covering inference branches, both serialization branches (object rows with/without header), and eval-time error branches for inconsistent or duplicate keys, and update `tests/spec_tests/config.yaml` to stop xfail-ing the `write_tsv_task.wdl` spec example.

### Testing
- Ran `mypy WDL/StdLib.py` and it reported no issues (success).
- Ran the focused unit test `python -m unittest -f tests.test_5stdlib.TestStdLib.test_write_tsv_unit_branches` and related `test_read_tsv_unit_branches`; both passed in this environment (success).
- Noted that some broader integration tests that exercise `miniwdl run` (e.g. `test_write`) require Docker and failed in this environment due to an unavailable Docker daemon/socket, which is an environmental issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d7927ec08333b812811ebeb4b8fb)