### PR TITLE
Implement `join_paths` stdlib function (WDL 1.2) and add tests

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -201,6 +201,7 @@ class Base:
             self.chunk = _Chunk()
             self.values = _Values()
             self.contains_key = _ContainsKey()
+            self.join_paths = _JoinPaths()
 
     def _read(self, parse: Callable[[str], Value.Base]) -> Callable[[Value.File], Value.Base]:
         "generate read_* function implementation based on parse"
@@ -1878,3 +1879,49 @@ class _ContainsKey(EagerFunction):
 
         # Successfully navigated the entire key path
         return Value.Boolean(True)
+
+
+class _JoinPaths(EagerFunction):
+    # String join_paths(Directory, String)
+    # String join_paths(Directory, Array[String]+)
+    # String join_paths(Array[String]+)
+
+    def infer_type(self, expr: "Expr.Apply") -> Type.Base:
+        if len(expr.arguments) not in (1, 2):
+            raise Error.WrongArity(expr, 2)
+        if len(expr.arguments) == 1:
+            expr.arguments[0].typecheck(Type.Array(Type.String()))
+            return Type.String()
+
+        expr.arguments[0].typecheck(Type.Directory())
+        arg2ty = expr.arguments[1].type
+        if isinstance(arg2ty, Type.String):
+            return Type.String()
+        if isinstance(arg2ty, Type.Array) and isinstance(arg2ty.item_type, Type.String):
+            return Type.String()
+        raise Error.StaticTypeMismatch(
+            expr.arguments[1], Type.String(), arg2ty, "for join_paths() argument #2"
+        )
+
+    def _call_eager(self, expr: "Expr.Apply", arguments: List[Value.Base]) -> Value.Base:
+        if len(arguments) == 1:
+            segments = arguments[0].coerce(Type.Array(Type.String())).value
+        else:
+            base = arguments[0].coerce(Type.Directory()).value
+            rhs = arguments[1]
+            if isinstance(rhs, Value.Array):
+                segments = [Value.String(base)] + rhs.coerce(Type.Array(Type.String())).value
+            else:
+                segments = [Value.String(base), rhs.coerce(Type.String())]
+
+        if not segments:
+            raise Error.EvalError(expr, "join_paths() requires at least one path segment")
+
+        segment_strings = [seg.coerce(Type.String()).value for seg in segments]
+        for i, segment in enumerate(segment_strings[1:], start=2):
+            if os.path.isabs(segment):
+                raise Error.EvalError(
+                    expr,
+                    f"join_paths() only allows an absolute path in the first segment (segment #{i})",
+                )
+        return Value.String(os.path.join(*segment_strings))

--- a/tests/spec_tests/config.yaml
+++ b/tests/spec_tests/config.yaml
@@ -21,7 +21,6 @@ wdl-1.2:
   xfail:
     # FIXME:
     - chunk_array.wdl
-    - join_paths_task.wdl
     - relative_paths_context.wdl  # issue #869
     - write_tsv_task.wdl
     # Known spec deviations:

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -1,10 +1,8 @@
-from math import exp
 import unittest
 import logging
 import tempfile
 import os
 import json
-import docker
 from .context import WDL
 
 class TestStdLib(unittest.TestCase):
@@ -242,7 +240,7 @@ class TestStdLib(unittest.TestCase):
         doc.typecheck()
 
 
-    def test_stdlib_branch_coverage_length_contains_key(self):
+    def test_stdlib_branch_coverage_length_contains_key_join_paths(self):
         # length(): wrong arity and optional argument rejection during quantifier checks
         with self.assertRaises(WDL.Error.WrongArity):
             self._eval_expr("length([1], [2])", version="1.2")
@@ -287,6 +285,38 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(str(self._eval_expr('contains_key({"a": 1}, ["a", "b"])', version="1.2")), "false")
         env = WDL.Env.Bindings().bind("path", WDL.Value.Array(WDL.Type.String(), []))
         self.assertEqual(str(self._eval_expr('contains_key({"a": 1}, path)', env=env, version="1.2")), "false")
+
+        # join_paths(): static type checks
+        with self.assertRaises(WDL.Error.WrongArity):
+            self._eval_expr('join_paths("a", "b", "c")', version="1.2")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._eval_expr('join_paths(1)', version="1.2")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._eval_expr('join_paths("base", 1)', version="1.2")
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            self._eval_expr('join_paths("base", [1])', version="1.2")
+
+        # join_paths(): successful overloads
+        self.assertEqual(
+            str(self._eval_expr('join_paths(["/a", "b", "c"])', version="1.2")),
+            '"/a/b/c"',
+        )
+        self.assertEqual(
+            str(self._eval_expr('join_paths("/a", "b/c")', version="1.2")),
+            '"/a/b/c"',
+        )
+        self.assertEqual(
+            str(self._eval_expr('join_paths("/a", ["b", "c"])', version="1.2")),
+            '"/a/b/c"',
+        )
+
+        # join_paths(): runtime path constraints
+        with self.assertRaises(WDL.Error.EvalError):
+            self._eval_expr('join_paths([])', version="1.2")
+        with self.assertRaises(WDL.Error.EvalError):
+            self._eval_expr('join_paths(["/a", "/b"])', version="1.2")
+        with self.assertRaises(WDL.Error.EvalError):
+            self._eval_expr('join_paths("/a", ["/b"])', version="1.2")
 
     def test_collect_by_key_float_keys(self):
         self.assertEqual(


### PR DESCRIPTION
### Motivation

- Provide a WDL 1.2 `join_paths` standard library implementation so spec conformance and unit tests can validate path-joining semantics.
- Exercise static and runtime validation for the new function in the stdlib test coverage.
- Update test configuration to stop x-failing the `join_paths` conformance case now that the function is implemented.

### Description

- Add a `_JoinPaths` `EagerFunction` that is registered on `StdLib.Base` for WDL `1.2` and implements the `join_paths` overloads and behavior.
- Implement `infer_type` to validate arity and argument types for the overloads `join_paths(Array[String]+)`, `join_paths(Directory, String)`, and `join_paths(Directory, Array[String]+)` and to return `Type.String()`.
- Implement `_call_eager` to coerce inputs to strings, require at least one segment, forbid absolute paths in non-first segments, and return the joined path using `os.path.join`.
- Update `tests/spec_tests/config.yaml` to remove `join_paths_task.wdl` from the `xfail` list for `wdl-1.2`.
- Extend `tests/test_5stdlib.py` to cover `join_paths` static type checks, successful overloads, and runtime path-constraint errors, and remove a couple of unused imports.

### Testing

- Ran the modified stdlib unit tests in `tests/test_5stdlib.py` which exercise `join_paths` static and runtime behavior, and they passed.
- Existing stdlib-related tests that were exercised by the change also passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d7c02c2c83339e336c35977e73bf)